### PR TITLE
BF: have to reinclude explicitly .github/workflows/ folder and files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,7 @@ src/scripts/__pycache__/
 **.pyc
 **__pycache__
 **
+!.github/
+!.github/workflows/
+!.github/workflows/**
 src/ontology/tmp/*


### PR DESCRIPTION
Otherwise git would keep ignoring them!

    ❯ git add .github/workflows/code*
    The following paths are ignored by one of your .gitignore files:
    .github/workflows/codespell.yml
    hint: Use -f if you really want to add them.
    hint: Disable this message with "git config set advice.addIgnoredFile false"